### PR TITLE
Add preferFlutter and preferDart environment fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.3.0
+- Add `preferFlutter` and `preferDart` environment fields to pin exact versions for tooling (linting/formatting) while maintaining broad version support in pub packages ([#6](https://github.com/phntmxyz/puro_sidekick_plugin/pull/6))
+  ```yaml
+  environment:
+    preferFlutter: '3.22.1'    # Used by puro
+    flutter: '>=3.0.0 <4.0.0'  # Broad support for users
+    sdk: '>=3.0.0 <4.0.0'
+  ```
+- These fields must be exact versions (not ranges) and take priority over `flutter`/`sdk` constraints
+
 ## 1.2.1
 - Check all published Flutter+Dart combinations when selecting a Flutter SDK (including beta)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ environment:
 <cli> flutter --version // Outputs Flutter version 3.19.6
 ```
 
+### Preferred Version for Pub Packages
+
+When developing pub packages that support a wide range of Flutter/Dart versions, you often want to use a specific version for linting and formatting while maintaining broad compatibility. Use `preferFlutter` or `preferDart` to pin an exact version for tooling without affecting your package's version constraints:
+
+```yaml
+name: my_pub_package
+
+environment:
+  preferFlutter: '3.22.1'    # Used by puro for linting/formatting
+  flutter: '>=3.0.0 <4.0.0'  # Broad support range for package users
+  sdk: '>=3.0.0 <4.0.0'
+```
+
+```bash
+<cli> flutter --version // Outputs Flutter version 3.22.1 (from preferFlutter)
+<cli> dart format .     // Uses Dart 3.4.1 (bundled with Flutter 3.22.1)
+```
+
+You can also use `preferDart` if you only need to pin the Dart version:
+
+```yaml
+name: my_dart_package
+
+environment:
+  preferDart: '3.4.1'        # Used by puro for linting/formatting
+  sdk: '>=3.0.0 <4.0.0'      # Broad support range for package users
+```
+
+**Priority order:**
+1. `preferFlutter` (highest - overrides everything)
+2. `flutter`
+3. `preferDart`
+4. `sdk` (lowest)
+
+**Note:** `preferFlutter` and `preferDart` must be exact versions (e.g., `'3.22.1'`), not ranges. Using a range like `'^3.22.0'` will result in an error.
+
 ### Workspace
 
 You can add `resolution: workspace` to your package-level `pubspec.yaml` to always use the Flutter and Dart versions from the root `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puro_sidekick_plugin
 description: Sidekick plugin that uses the Flutter SDK managed by Puro in the repository and links it to the flutter and dart commands
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/phntmxyz/puro_sidekick_plugin
 issue_tracker: https://github.com/phntmxyz/puro_sidekick_plugin/issues
 topics:


### PR DESCRIPTION
## Summary

- Add `preferFlutter` and `preferDart` environment fields to pin exact versions for tooling (linting/formatting) while maintaining broad version support in pub packages
- These fields must be exact versions (not ranges) and take priority over `flutter`/`sdk` constraints
- Priority order: `preferFlutter` > `flutter` > `preferDart` > `sdk`

## Example

```yaml
name: my_pub_package

environment:
  preferFlutter: '3.22.1'    # Used by puro for linting/formatting
  flutter: '>=3.0.0 <4.0.0'  # Broad support range for package users
  sdk: '>=3.0.0 <4.0.0'
```

## Test plan

- [x] Added tests for `preferFlutter` overriding `flutter` and `sdk` constraints
- [x] Added tests for `preferDart` overriding `sdk` constraint
- [x] Added tests for validation (throws on range constraints)
- [x] All 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)