### PR TITLE
Move puro config from environment to sidekick.puro section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Changelog
 
-## 1.3.0
-- Add `preferFlutter` and `preferDart` environment fields to pin exact versions for tooling (linting/formatting) while maintaining broad version support in pub packages ([#6](https://github.com/phntmxyz/puro_sidekick_plugin/pull/6))
+## 1.3.1
+- Move puro configuration from `environment` to `sidekick.puro` section in pubspec.yaml
+  - `environment.preferFlutter` is now `sidekick.puro.useFlutterSdk`
+  - `environment.preferDart` is now `sidekick.puro.useDartSdk`
+  - This fixes compatibility issues with pub.dev validation (environment only allows standard keys)
   ```yaml
   environment:
-    preferFlutter: '3.22.1'    # Used by puro
     flutter: '>=3.0.0 <4.0.0'  # Broad support for users
     sdk: '>=3.0.0 <4.0.0'
+  
+  sidekick:
+    puro:
+      useFlutterSdk: '3.22.1'  # Used by puro_sidekick_plugin
+      useDartSdk: '3.4.1'      
   ```
-- These fields must be exact versions (not ranges) and take priority over `flutter`/`sdk` constraints
+
+## 1.3.0 (retracted)
+- Retracted: `environment` section in pubspec.yaml doesn't allow custom keys like `environment.preferFlutter`
 
 ## 1.2.1
 - Check all published Flutter+Dart combinations when selecting a Flutter SDK (including beta)

--- a/README.md
+++ b/README.md
@@ -60,39 +60,45 @@ environment:
 
 ### Preferred Version for Pub Packages
 
-When developing pub packages that support a wide range of Flutter/Dart versions, you often want to use a specific version for linting and formatting while maintaining broad compatibility. Use `preferFlutter` or `preferDart` to pin an exact version for tooling without affecting your package's version constraints:
+When developing pub packages that support a wide range of Flutter/Dart versions, you often want to use a specific version for linting and formatting while maintaining broad compatibility. Use `sidekick.puro.useFlutterSdk` or `sidekick.puro.useDartSdk` to pin an exact version for tooling without affecting your package's version constraints:
 
 ```yaml
 name: my_pub_package
 
+sidekick:
+  puro:
+    useFlutterSdk: '3.22.1'  # Used by puro for linting/formatting
+
 environment:
-  preferFlutter: '3.22.1'    # Used by puro for linting/formatting
   flutter: '>=3.0.0 <4.0.0'  # Broad support range for package users
   sdk: '>=3.0.0 <4.0.0'
 ```
 
 ```bash
-<cli> flutter --version // Outputs Flutter version 3.22.1 (from preferFlutter)
+<cli> flutter --version // Outputs Flutter version 3.22.1 (from useFlutterSdk)
 <cli> dart format .     // Uses Dart 3.4.1 (bundled with Flutter 3.22.1)
 ```
 
-You can also use `preferDart` if you only need to pin the Dart version:
+You can also use `useDartSdk` if you only need to pin the Dart version:
 
 ```yaml
 name: my_dart_package
 
+sidekick:
+  puro:
+    useDartSdk: '3.4.1'      # Used by puro for linting/formatting
+
 environment:
-  preferDart: '3.4.1'        # Used by puro for linting/formatting
   sdk: '>=3.0.0 <4.0.0'      # Broad support range for package users
 ```
 
 **Priority order:**
-1. `preferFlutter` (highest - overrides everything)
+1. `sidekick.puro.useFlutterSdk` (highest - overrides everything)
 2. `flutter`
-3. `preferDart`
+3. `sidekick.puro.useDartSdk`
 4. `sdk` (lowest)
 
-**Note:** `preferFlutter` and `preferDart` must be exact versions (e.g., `'3.22.1'`), not ranges. Using a range like `'^3.22.0'` will result in an error.
+**Note:** `useFlutterSdk` and `useDartSdk` must be exact versions (e.g., `'3.22.1'`), not ranges. Using a range like `'^3.22.0'` will result in an error.
 
 ### Workspace
 

--- a/lib/src/version_parser.dart
+++ b/lib/src/version_parser.dart
@@ -54,21 +54,25 @@ class VersionParser {
       // Check for environment
       final environment = pubspec['environment'] as YamlMap?;
 
-      // Get preferFlutter version if available (highest priority override)
+      // Check for sidekick.puro configuration (preferred SDK versions)
+      final sidekick = pubspec['sidekick'] as YamlMap?;
+      final puroConfig = sidekick?['puro'] as YamlMap?;
+
+      // Get useFlutterSdk version if available (highest priority override)
       // Must be an exact version, not a range
-      final preferFlutter = environment?['preferFlutter'] as String?;
-      if (preferFlutter != null) {
-        _validateExactVersion(preferFlutter, 'preferFlutter');
+      final useFlutterSdk = puroConfig?['useFlutterSdk'] as String?;
+      if (useFlutterSdk != null) {
+        _validateExactVersion(useFlutterSdk, 'useFlutterSdk');
       }
 
       // Get flutter version if available
       final flutterConstraint = environment?['flutter'] as String?;
 
-      // Get preferDart version if available (overrides sdk)
+      // Get useDartSdk version if available (overrides sdk)
       // Must be an exact version, not a range
-      final preferDart = environment?['preferDart'] as String?;
-      if (preferDart != null) {
-        _validateExactVersion(preferDart, 'preferDart');
+      final useDartSdk = puroConfig?['useDartSdk'] as String?;
+      if (useDartSdk != null) {
+        _validateExactVersion(useDartSdk, 'useDartSdk');
       }
 
       // Get dart sdk version if flutter version is not available
@@ -77,19 +81,19 @@ class VersionParser {
       /// Dart Version => Flutter Version
       final availableVersions = await _parseAvailableVersions();
 
-      // preferFlutter takes priority over flutter and sdk constraints
-      // preferDart takes priority over sdk constraint
+      // useFlutterSdk takes priority over flutter and sdk constraints
+      // useDartSdk takes priority over sdk constraint
       // This is useful for packages that support multiple versions but want
       // to use a specific version for linting and formatting as default
-      final effectiveFlutterConstraint = preferFlutter ?? flutterConstraint;
-      final effectiveDartConstraint = preferDart ?? dartConstraint;
+      final effectiveFlutterConstraint = useFlutterSdk ?? flutterConstraint;
+      final effectiveDartConstraint = useDartSdk ?? dartConstraint;
 
       if (effectiveFlutterConstraint != null) {
         final flutterVersion =
             VersionConstraint.parse(effectiveFlutterConstraint);
-        if (preferFlutter != null) {
+        if (useFlutterSdk != null) {
           printVerbose(
-            'Found preferFlutter version: $flutterVersion (overrides flutter/sdk)',
+            'Found useFlutterSdk version: $flutterVersion (overrides flutter/sdk)',
           );
         } else {
           printVerbose('Found flutter version constraint: $flutterVersion');
@@ -109,9 +113,9 @@ class VersionParser {
         }
       } else if (effectiveDartConstraint != null) {
         final dartVersion = VersionConstraint.parse(effectiveDartConstraint);
-        if (preferDart != null) {
+        if (useDartSdk != null) {
           printVerbose(
-            'Found preferDart version: $dartVersion (overrides sdk)',
+            'Found useDartSdk version: $dartVersion (overrides sdk)',
           );
         } else {
           printVerbose('Found dart version constraint: $dartVersion');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puro_sidekick_plugin
 description: Sidekick plugin that uses the Flutter SDK managed by Puro in the repository and links it to the flutter and dart commands
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/phntmxyz/puro_sidekick_plugin
 issue_tracker: https://github.com/phntmxyz/puro_sidekick_plugin/issues
 topics:

--- a/test/version_parser_test.dart
+++ b/test/version_parser_test.dart
@@ -228,12 +228,15 @@ environment:
     );
   });
 
-  test('preferFlutter overrides both flutter and sdk constraints', () async {
+  test('useFlutterSdk overrides both flutter and sdk constraints', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useFlutterSdk: '3.22.1'
+
 environment:
-  preferFlutter: '3.22.1'
   flutter: '>=3.0.0 <4.0.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
@@ -244,20 +247,23 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // preferFlutter: 3.22.1 should be used instead of flutter or sdk constraints
+    // useFlutterSdk: 3.22.1 should be used instead of flutter or sdk constraints
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.22.1', '3.4.1'),
     );
   });
 
-  test('preferFlutter overrides sdk constraint when flutter is not present',
+  test('useFlutterSdk overrides sdk constraint when flutter is not present',
       () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useFlutterSdk: '3.19.4'
+
 environment:
-  preferFlutter: '3.19.4'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -267,14 +273,14 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // preferFlutter: 3.19.4 should be used instead of sdk constraint
+    // useFlutterSdk: 3.19.4 should be used instead of sdk constraint
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.19.4', '3.3.2'),
     );
   });
 
-  test('flutter constraint is used when preferFlutter is not present',
+  test('flutter constraint is used when useFlutterSdk is not present',
       () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
@@ -290,19 +296,22 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // Should still work when preferFlutter is not present
+    // Should still work when useFlutterSdk is not present
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.22.1', '3.4.1'),
     );
   });
 
-  test('preferDart overrides sdk constraint', () async {
+  test('useDartSdk overrides sdk constraint', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useDartSdk: '3.4.1'
+
 environment:
-  preferDart: '3.4.1'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -312,20 +321,23 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // preferDart: 3.4.1 should be used instead of sdk constraint
+    // useDartSdk: 3.4.1 should be used instead of sdk constraint
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.22.1', '3.4.1'),
     );
   });
 
-  test('preferFlutter takes priority over preferDart', () async {
+  test('useFlutterSdk takes priority over useDartSdk', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useFlutterSdk: '3.22.1'
+    useDartSdk: '3.2.6'
+
 environment:
-  preferFlutter: '3.22.1'
-  preferDart: '3.2.6'
   flutter: '>=3.0.0 <4.0.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
@@ -336,14 +348,14 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // preferFlutter should take priority over preferDart
+    // useFlutterSdk should take priority over useDartSdk
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.22.1', '3.4.1'),
     );
   });
 
-  test('sdk constraint is used when preferDart is not present', () async {
+  test('sdk constraint is used when useDartSdk is not present', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
@@ -357,19 +369,22 @@ environment:
       puroLsVersionsProvider: () => _puroLsVersions,
     );
 
-    // Should still work when preferDart is not present
+    // Should still work when useDartSdk is not present
     expect(
       await parser.getMaxFlutterSdkVersionFromPubspec(),
       FlutterSdkVersions.fromString('3.22.1', '3.4.1'),
     );
   });
 
-  test('preferFlutter throws when given a range constraint', () async {
+  test('useFlutterSdk throws when given a range constraint', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useFlutterSdk: '>=3.19.0 <4.0.0'
+
 environment:
-  preferFlutter: '>=3.19.0 <4.0.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -385,18 +400,21 @@ environment:
         isA<VersionParserException>().having(
           (e) => e.msg,
           'msg',
-          contains('preferFlutter must be an exact version'),
+          contains('useFlutterSdk must be an exact version'),
         ),
       ),
     );
   });
 
-  test('preferFlutter throws when given a caret constraint', () async {
+  test('useFlutterSdk throws when given a caret constraint', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useFlutterSdk: '^3.19.0'
+
 environment:
-  preferFlutter: '^3.19.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -412,18 +430,21 @@ environment:
         isA<VersionParserException>().having(
           (e) => e.msg,
           'msg',
-          contains('preferFlutter must be an exact version'),
+          contains('useFlutterSdk must be an exact version'),
         ),
       ),
     );
   });
 
-  test('preferDart throws when given a range constraint', () async {
+  test('useDartSdk throws when given a range constraint', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useDartSdk: '>=3.3.0 <4.0.0'
+
 environment:
-  preferDart: '>=3.3.0 <4.0.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -439,18 +460,21 @@ environment:
         isA<VersionParserException>().having(
           (e) => e.msg,
           'msg',
-          contains('preferDart must be an exact version'),
+          contains('useDartSdk must be an exact version'),
         ),
       ),
     );
   });
 
-  test('preferDart throws when given a caret constraint', () async {
+  test('useDartSdk throws when given a caret constraint', () async {
     const pubspecYaml = '''
 name: puro_sidekick_plugin
 
+sidekick:
+  puro:
+    useDartSdk: '^3.3.0'
+
 environment:
-  preferDart: '^3.3.0'
   sdk: '>=3.0.0 <4.0.0'
 ''';
 
@@ -466,7 +490,7 @@ environment:
         isA<VersionParserException>().having(
           (e) => e.msg,
           'msg',
-          contains('preferDart must be an exact version'),
+          contains('useDartSdk must be an exact version'),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Move puro SDK configuration from `environment` to `sidekick.puro` section in pubspec.yaml
- Rename `preferFlutter` to `useFlutterSdk` and `preferDart` to `useDartSdk`
- Fixes pub.dev validation errors (environment only allows standard keys like `sdk` and `flutter`)

## Migration
```yaml
# Before (1.3.0 - broken)
environment:
  preferFlutter: '3.22.1'
  sdk: '>=3.0.0 <4.0.0'

# After (1.3.1)
sidekick:
  puro:
    useFlutterSdk: '3.22.1'

environment:
  sdk: '>=3.0.0 <4.0.0'
```

## Test plan
- [x] All existing tests updated and passing
- [x] Verified new pubspec.yaml structure is parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)