### PR TITLE
Handle GitHub API rate limits gracefully

### DIFF
--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -83,6 +83,7 @@ Future<void> initializePuro(SdkInitializerContext context) async {
   dcli.env['PURO_FLUTTER_BIN'] = null;
 
   final packageDir = context.packageDir?.root ?? SidekickContext.projectRoot;
+  final package = DartPackage.fromDirectory(packageDir);
   final versions = await VersionParser(
     packagePath: packageDir,
     projectRoot: SidekickContext.projectRoot,
@@ -101,9 +102,16 @@ Future<void> initializePuro(SdkInitializerContext context) async {
   dcli.env['PURO_FLUTTER_BIN'] = flutterBinPath.absolute.path;
   createSymlink(symlinkPath, flutterPath);
 
-  print(
-    'Using Flutter ${versions.flutterVersion} (Dart ${versions.dartVersion})',
-  );
+  final isFlutterPackage = package?.isFlutterPackage ?? false;
+  if (isFlutterPackage) {
+    print(
+      'Using Flutter ${versions.flutterVersion} (Dart ${versions.dartVersion})',
+    );
+  } else {
+    print(
+      'Using Dart ${versions.dartVersion} (via Flutter ${versions.flutterVersion})',
+    );
+  }
 }
 
 Future<void> _createPuroEnvironment(

--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -101,11 +101,20 @@ Future<void> _createPuroEnvironment(
   Directory packageDir,
   Version flutterSdkVersion,
 ) async {
-  final progress = Progress.capture();
-  await puro(['ls'], progress: progress);
-  final currentEnvs = progress.lines.join('\n');
+  final progress = Progress.capture(captureStderr: true);
+  // nothrow: true because puro ls may fail if no environments exist yet
+  final result = await puro(['ls'], progress: progress, nothrow: true);
 
   final versionString = flutterSdkVersion.toString();
+  final currentEnvs = progress.lines.join('\n');
+
+  if (result.exitCode != 0) {
+    print('puro ls failed with exit code ${result.exitCode}');
+    if (progress.lines.isNotEmpty) {
+      print('output:\n${progress.lines.join('\n')}');
+    }
+  }
+
   if (!currentEnvs.contains(versionString)) {
     printVerbose('Create new Puro environment: $flutterSdkVersion');
     await puro(

--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -60,7 +60,16 @@ Future<void> initializePuro(SdkInitializerContext context) async {
       if (currentPuro.standalone) {
         puroRootDir = installPuro();
       } else {
-        await puro(['upgrade-puro'], progress: Progress.print());
+        final progress = Progress.capture(captureStderr: true);
+        try {
+          await puro(['upgrade-puro'], progress: progress);
+        } catch (e, stackTrace) {
+          print('puro upgrade-puro failed: $e');
+          print(stackTrace);
+          if (progress.lines.isNotEmpty) {
+            print('output:\n${progress.lines.join('\n')}');
+          }
+        }
         puroRootDir = puroPath!.parent.parent;
       }
       dcli.env['PURO_ROOT'] = puroRootDir.absolute.path;
@@ -101,26 +110,38 @@ Future<void> _createPuroEnvironment(
   Directory packageDir,
   Version flutterSdkVersion,
 ) async {
-  final progress = Progress.capture(captureStderr: true);
-  // nothrow: true because puro ls may fail if no environments exist yet
-  final result = await puro(['ls'], progress: progress, nothrow: true);
-
   final versionString = flutterSdkVersion.toString();
-  final currentEnvs = progress.lines.join('\n');
+  String currentEnvs = '';
 
-  if (result.exitCode != 0) {
-    print('puro ls failed with exit code ${result.exitCode}');
-    if (progress.lines.isNotEmpty) {
-      print('output:\n${progress.lines.join('\n')}');
+  // puro ls may fail if no environments exist yet
+  final lsProgress = Progress.capture(captureStderr: true);
+  try {
+    await puro(['ls'], progress: lsProgress);
+    currentEnvs = lsProgress.lines.join('\n');
+  } catch (e, stackTrace) {
+    print('puro ls failed: $e');
+    print(stackTrace);
+    if (lsProgress.lines.isNotEmpty) {
+      print('output:\n${lsProgress.lines.join('\n')}');
     }
   }
 
   if (!currentEnvs.contains(versionString)) {
     printVerbose('Create new Puro environment: $flutterSdkVersion');
-    await puro(
-      ['create', versionString, versionString],
-      progress: Progress.print(),
-    );
+    final createProgress = Progress.capture(captureStderr: true);
+    try {
+      await puro(
+        ['create', versionString, versionString],
+        progress: createProgress,
+      );
+    } catch (e, stackTrace) {
+      print('puro create failed: $e');
+      print(stackTrace);
+      if (createProgress.lines.isNotEmpty) {
+        print('output:\n${createProgress.lines.join('\n')}');
+      }
+      rethrow;
+    }
   }
 }
 
@@ -130,10 +151,20 @@ Future<void> _binPuroToProject(
 ) async {
   final versionString = flutterSdkVersion.toString();
   printVerbose('Use Puro environment: $versionString');
-  await puro(
-    ['use', '--project', packageDir.absolute.path, versionString],
-    progress: Progress.printStdErr(),
-  );
+  final progress = Progress.capture(captureStderr: true);
+  try {
+    await puro(
+      ['use', '--project', packageDir.absolute.path, versionString],
+      progress: progress,
+    );
+  } catch (e, stackTrace) {
+    print('puro use failed: $e');
+    print(stackTrace);
+    if (progress.lines.isNotEmpty) {
+      print('output:\n${progress.lines.join('\n')}');
+    }
+    rethrow;
+  }
 }
 
 /// Thrown when puro could not be installed
@@ -147,16 +178,26 @@ class PuroInstallationFailedException implements Exception {
 Future<({bool standalone, String version})> getCurrentPuroVersion() async {
   final puroPath = getPuroPath();
   if (puroPath == null) {
-    throw PuroInstallationFailedException();
+    throw PuroNotFoundException();
   }
-  final progress = Progress.capture();
-  await puro(
-    ['--version'],
-    progress: progress,
-    workingDirectory: puroPath.parent.parent.absolute,
-  );
+  final progress = Progress.capture(captureStderr: true);
+  try {
+    await puro(
+      ['--version'],
+      progress: progress,
+      workingDirectory: puroPath.parent.parent.absolute,
+    );
+  } catch (e, stackTrace) {
+    print('puro --version failed: $e');
+    print(stackTrace);
+    if (progress.lines.isNotEmpty) {
+      print('output:\n${progress.lines.join('\n')}');
+    }
+    rethrow;
+  }
   final versionLine = progress.lines.firstWhere(
     (line) => line.contains('[i] Puro'),
+    orElse: () => '',
   );
 
   final regex = RegExp(r'\b\d+\.\d+\.\d+\b');
@@ -167,7 +208,10 @@ Future<({bool standalone, String version})> getCurrentPuroVersion() async {
     version = match.group(0);
   }
   if (version == null) {
-    throw PuroInstallationFailedException();
+    final output = progress.lines.join('\n');
+    throw Exception(
+      'Could not parse puro version from output:\n$output',
+    );
   }
   final standalone = versionLine.contains('standalone');
   return (standalone: standalone, version: version);

--- a/lib/src/flutter_sdk.dart
+++ b/lib/src/flutter_sdk.dart
@@ -16,12 +16,21 @@ String flutterSdkSymlink() {
 Future<String> puroFlutterSdkPath(Directory packageDir) async {
   String? envPath;
   final pathMatcher = RegExp(r'.*executing: \[(.*)\].*');
-  final progress = Progress.capture();
-  await puro(
-    ['flutter', '-v', '--version'],
-    progress: progress,
-    workingDirectory: packageDir,
-  );
+  final progress = Progress.capture(captureStderr: true);
+  try {
+    await puro(
+      ['flutter', '-v', '--version'],
+      progress: progress,
+      workingDirectory: packageDir,
+    );
+  } catch (e, stackTrace) {
+    print('puro flutter --version failed: $e');
+    print(stackTrace);
+    if (progress.lines.isNotEmpty) {
+      print('output:\n${progress.lines.join('\n')}');
+    }
+    throw PuroNotFoundException();
+  }
   final currentEnvs = progress.lines.join('\n');
   final match = pathMatcher.firstMatch(currentEnvs);
   if (match != null) {

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -92,14 +92,40 @@ Directory installPuroStandalone(String version, dcli.Progress? progress) {
   return downloadPath.parent;
 }
 
+/// Default cache TTL of 24 hours
+const _cacheTtl = Duration(hours: 24);
+
+/// Checks if a cache file is still valid (exists and not expired).
+bool _isCacheValid(File cacheFile, {Duration ttl = _cacheTtl}) {
+  if (!cacheFile.existsSync()) return false;
+  final lastModified = cacheFile.lastModifiedSync();
+  return DateTime.now().difference(lastModified) < ttl;
+}
+
 /// Fetches the latest Puro version from GitHub releases.
 ///
+/// The result is cached in the build folder for 24 hours.
 /// [githubReleasesProvider] can be overridden for testing.
+/// [cacheFile] can be overridden for testing.
 String getLatestPuroVersion({
   String Function()? githubReleasesProvider,
+  File? cacheFile,
 }) {
+  cacheFile ??= File(
+    '${SidekickContext.sidekickPackage.buildDir.path}/puro_latest_version.txt',
+  );
+
+  // Return cached version if available and not expired
+  if (_isCacheValid(cacheFile)) {
+    final cached = cacheFile.readAsStringSync().trim();
+    if (cached.isNotEmpty) {
+      return cached;
+    }
+  }
+
   try {
-    final resultJson = githubReleasesProvider?.call() ?? _fetchLatestPuroReleaseJson();
+    final resultJson =
+        githubReleasesProvider?.call() ?? _fetchLatestPuroReleaseJson();
     if (resultJson == null) {
       return puroFallbackVersion;
     }
@@ -113,6 +139,14 @@ String getLatestPuroVersion({
       print('Missing or invalid tag_name in GitHub API response');
       return puroFallbackVersion;
     }
+
+    // Cache the version (delete first to reset last modified time)
+    if (cacheFile.existsSync()) {
+      cacheFile.deleteSync();
+    }
+    cacheFile.parent.createSync(recursive: true);
+    cacheFile.writeAsStringSync(tagName);
+
     return tagName;
   } catch (e) {
     print('Failed to get the latest Puro version: $e');

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -92,28 +92,45 @@ Directory installPuroStandalone(String version, dcli.Progress? progress) {
   return downloadPath.parent;
 }
 
-String getLatestPuroVersion() {
+/// Fetches the latest Puro version from GitHub releases.
+///
+/// [githubReleasesProvider] can be overridden for testing.
+String getLatestPuroVersion({
+  String Function()? githubReleasesProvider,
+}) {
   try {
-    final output = dcli.startFromArgs(
-      'curl',
-      ['https://api.github.com/repos/pingbird/puro/releases?per_page=1&page=1'],
-      progress: Progress.capture(captureStderr: false),
-    );
-    if (output.exitCode != 0) {
-      print('Failed to get the latest Puro version.');
+    final resultJson = githubReleasesProvider?.call() ?? _fetchLatestPuroReleaseJson();
+    if (resultJson == null) {
       return puroFallbackVersion;
     }
-    final resultJson = output.lines.join('\n');
     final result = jsonDecode(resultJson);
     if (result is! List || result.isEmpty) {
       print('Unexpected response from GitHub API: $resultJson');
       return puroFallbackVersion;
     }
-    return (result[0] as Map<String, dynamic>)['tag_name'] as String;
+    final tagName = (result[0] as Map<String, dynamic>)['tag_name'];
+    if (tagName is! String) {
+      print('Missing or invalid tag_name in GitHub API response');
+      return puroFallbackVersion;
+    }
+    return tagName;
   } catch (e) {
     print('Failed to get the latest Puro version: $e');
     return puroFallbackVersion;
   }
+}
+
+String? _fetchLatestPuroReleaseJson() {
+  final output = dcli.startFromArgs(
+    'curl',
+    ['https://api.github.com/repos/pingbird/puro/releases?per_page=1&page=1'],
+    progress: Progress.capture(captureStderr: false),
+  );
+  if (output.exitCode != 0) {
+    print('Failed to get the latest Puro version.');
+    return null;
+  }
+  return output.lines.join('\n');
 }
 
 int installPuroStandaloneMacOs(

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -4,7 +4,7 @@ import 'package:dcli/dcli.dart' as dcli;
 import 'package:puro_sidekick_plugin/puro_sidekick_plugin.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
-const puroFallbackVersion = '1.4.10';
+const puroFallbackVersion = '1.5.0';
 
 /// Executes Flutter CLI via puro
 ///

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -94,18 +94,22 @@ Directory installPuroStandalone(String version, dcli.Progress? progress) {
 
 String getLatestPuroVersion() {
   try {
-    const command =
-        'curl https://api.github.com/repos/pingbird/puro/releases?per_page=1&page=1';
-    final output =
-        dcli.start(command, progress: Progress.capture(captureStderr: false));
+    final output = dcli.startFromArgs(
+      'curl',
+      ['https://api.github.com/repos/pingbird/puro/releases?per_page=1&page=1'],
+      progress: Progress.capture(captureStderr: false),
+    );
     if (output.exitCode != 0) {
       print('Failed to get the latest Puro version.');
       return puroFallbackVersion;
     }
     final resultJson = output.lines.join('\n');
     final result = jsonDecode(resultJson);
-    return ((result as List<dynamic>)[0] as Map<String, dynamic>)['tag_name']
-        as String;
+    if (result is! List || result.isEmpty) {
+      print('Unexpected response from GitHub API: $resultJson');
+      return puroFallbackVersion;
+    }
+    return (result[0] as Map<String, dynamic>)['tag_name'] as String;
   } catch (e) {
     print('Failed to get the latest Puro version: $e');
     return puroFallbackVersion;

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -148,8 +148,9 @@ String getLatestPuroVersion({
     cacheFile.writeAsStringSync(tagName);
 
     return tagName;
-  } catch (e) {
+  } catch (e, stackTrace) {
     print('Failed to get the latest Puro version: $e');
+    print(stackTrace);
     return puroFallbackVersion;
   }
 }

--- a/lib/src/version_parser.dart
+++ b/lib/src/version_parser.dart
@@ -159,9 +159,9 @@ class VersionParser {
         msg: 'Error parsing pubspec.yaml',
         innerException: e,
       );
-    } catch (e) {
+    } catch (e, stackTrace) {
       throw VersionParserException(
-        msg: 'Unexpected error: $e',
+        msg: 'Unexpected error: $e\n$stackTrace',
       );
     }
   }
@@ -189,14 +189,14 @@ class VersionParser {
         }
       }
 
+      final progress = Progress.capture(captureStderr: true);
       try {
         // List all available flutter and dart versions
         await puro(
           ['ls-versions', '--full'],
-          progress: Progress((line) {
-            if (line.trim().isNotEmpty) lines.add(line);
-          }),
+          progress: progress,
         );
+        lines.addAll(progress.lines.where((l) => l.trim().isNotEmpty));
 
         // Cache the result (delete first to reset last modified time)
         if (cacheFile.existsSync()) {
@@ -204,8 +204,12 @@ class VersionParser {
         }
         cacheFile.parent.createSync(recursive: true);
         cacheFile.writeAsStringSync(lines.join('\n'));
-      } catch (e) {
-        print('Error getting flutter versions: $e');
+      } catch (e, stackTrace) {
+        print('puro ls-versions failed: $e');
+        print(stackTrace);
+        if (progress.lines.isNotEmpty) {
+          print('output:\n${progress.lines.join('\n')}');
+        }
       }
     }
     return lines;

--- a/lib/src/version_parser.dart
+++ b/lib/src/version_parser.dart
@@ -1,9 +1,20 @@
 import 'dart:collection';
+import 'dart:io' as io;
 
 import 'package:pub_semver/pub_semver.dart';
 import 'package:puro_sidekick_plugin/puro_sidekick_plugin.dart';
 import 'package:sidekick_core/sidekick_core.dart' hide Version;
 import 'package:yaml/yaml.dart';
+
+/// Default cache TTL of 24 hours
+const _cacheTtl = Duration(hours: 24);
+
+/// Checks if a cache file is still valid (exists and not expired).
+bool _isCacheValid(io.File cacheFile, {Duration ttl = _cacheTtl}) {
+  if (!cacheFile.existsSync()) return false;
+  final lastModified = cacheFile.lastModifiedSync();
+  return DateTime.now().difference(lastModified) < ttl;
+}
 
 /// `VersionParser` is a class that helps in parsing Flutter and Dart versions.
 ///
@@ -157,6 +168,7 @@ class VersionParser {
 
   /// Provides the available versions from puro ls-versions command
   /// If the `puroLsVersionsProvider` is provided, it uses that to get the versions
+  /// The result is cached in the build folder for 24 hours.
   /// Returns all stdout lines from the command as a list
   Future<List<String>> _provideAvailableVersions() async {
     final lines = <String>[];
@@ -164,6 +176,19 @@ class VersionParser {
     if (puroLsVersionsProvider != null) {
       lines.addAll(puroLsVersionsProvider!().split('\n'));
     } else {
+      // Check cache first
+      final cacheFile = io.File(
+        '${SidekickContext.sidekickPackage.buildDir.path}/puro_ls_versions.txt',
+      );
+
+      if (_isCacheValid(cacheFile)) {
+        final cached = cacheFile.readAsStringSync();
+        if (cached.isNotEmpty) {
+          lines.addAll(cached.split('\n').where((l) => l.trim().isNotEmpty));
+          return lines;
+        }
+      }
+
       try {
         // List all available flutter and dart versions
         await puro(
@@ -172,6 +197,13 @@ class VersionParser {
             if (line.trim().isNotEmpty) lines.add(line);
           }),
         );
+
+        // Cache the result (delete first to reset last modified time)
+        if (cacheFile.existsSync()) {
+          cacheFile.deleteSync();
+        }
+        cacheFile.parent.createSync(recursive: true);
+        cacheFile.writeAsStringSync(lines.join('\n'));
       } catch (e) {
         print('Error getting flutter versions: $e');
       }

--- a/test/install_puro_test.dart
+++ b/test/install_puro_test.dart
@@ -247,5 +247,67 @@ void main() {
       expect(version2, '1.1.0');
       expect(callCount, 1); // Still 1, provider wasn't called
     });
+
+    test('empty cache file triggers new fetch', () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.5.0"}]';
+      }
+
+      // Create empty cache file
+      cacheFile.createSync(recursive: true);
+      cacheFile.writeAsStringSync('');
+
+      final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version, '1.5.0');
+      expect(callCount, 1); // Provider was called because cache was empty
+    });
+
+    test('cache file with only whitespace triggers new fetch', () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.5.0"}]';
+      }
+
+      // Create cache file with only whitespace
+      cacheFile.createSync(recursive: true);
+      cacheFile.writeAsStringSync('   \n\t  ');
+
+      final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version, '1.5.0');
+      // Provider was called because cache was effectively empty
+      expect(callCount, 1);
+    });
+
+    test('cache file with invalid content is used as-is', () {
+      // Note: The cache file stores plain version strings, not JSON.
+      // If garbage is in the cache, it will be returned as-is until expired.
+      // This tests the current behavior - invalid cache content is trusted.
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.5.0"}]';
+      }
+
+      // Create cache file with garbage content
+      cacheFile.createSync(recursive: true);
+      cacheFile.writeAsStringSync('not-a-valid-version');
+
+      final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      // Current behavior: returns the garbage content without validation
+      expect(version, 'not-a-valid-version');
+      expect(callCount, 0); // Provider was NOT called - cache was used
+    });
   });
 }

--- a/test/install_puro_test.dart
+++ b/test/install_puro_test.dart
@@ -1,8 +1,22 @@
+import 'dart:io';
+
 import 'package:puro_sidekick_plugin/src/install_puro.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('getLatestPuroVersion', () {
+    late Directory tempDir;
+    late File cacheFile;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('puro_test_');
+      cacheFile = File('${tempDir.path}/puro_latest_version.txt');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
     test('parses valid GitHub releases response', () {
       const validResponse = '''
 [
@@ -15,6 +29,7 @@ void main() {
 ]
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => validResponse,
       );
       expect(version, '1.5.0');
@@ -29,12 +44,14 @@ void main() {
 ]
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => multipleReleases,
       );
       expect(version, '2.0.0');
     });
 
-    test('returns fallback for rate limit error response (Map instead of List)', () {
+    test('returns fallback for rate limit error response (Map instead of List)',
+        () {
       const rateLimitResponse = '''
 {
   "message": "API rate limit exceeded for 192.168.1.1.",
@@ -42,6 +59,7 @@ void main() {
 }
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => rateLimitResponse,
       );
       expect(version, puroFallbackVersion);
@@ -50,6 +68,7 @@ void main() {
     test('returns fallback for empty array response', () {
       const emptyArray = '[]';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => emptyArray,
       );
       expect(version, puroFallbackVersion);
@@ -58,6 +77,7 @@ void main() {
     test('returns fallback for invalid JSON', () {
       const invalidJson = 'not valid json';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => invalidJson,
       );
       expect(version, puroFallbackVersion);
@@ -73,6 +93,7 @@ void main() {
 ]
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => missingTagName,
       );
       expect(version, puroFallbackVersion);
@@ -88,13 +109,15 @@ void main() {
 ]
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => nullTagName,
       );
       expect(version, puroFallbackVersion);
     });
 
-    test('returns fallback when provider returns null', () {
+    test('returns fallback when provider throws', () {
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => throw Exception('Network error'),
       );
       expect(version, puroFallbackVersion);
@@ -109,9 +132,120 @@ void main() {
 </html>
 ''';
       final version = getLatestPuroVersion(
+        cacheFile: cacheFile,
         githubReleasesProvider: () => htmlResponse,
       );
       expect(version, puroFallbackVersion);
+    });
+
+    test('caches result to file and returns cached version on subsequent calls',
+        () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.5.0"}]';
+      }
+
+      // First call - fetches and caches
+      final version1 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version1, '1.5.0');
+      expect(callCount, 1);
+      expect(cacheFile.existsSync(), isTrue);
+      expect(cacheFile.readAsStringSync(), '1.5.0');
+
+      // Second call - should use cache, provider not called
+      final version2 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version2, '1.5.0');
+      expect(callCount, 1); // Still 1, provider wasn't called
+    });
+
+    test('clearing cache by deleting file forces new fetch', () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.${callCount}.0"}]';
+      }
+
+      // First call
+      final version1 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version1, '1.1.0');
+      expect(callCount, 1);
+
+      // Delete cache file
+      cacheFile.deleteSync();
+
+      // Second call - should fetch again
+      final version2 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version2, '1.2.0');
+      expect(callCount, 2);
+    });
+
+    test('expired cache (older than 24h) triggers new fetch', () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.${callCount}.0"}]';
+      }
+
+      // First call - creates cache
+      final version1 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version1, '1.1.0');
+      expect(callCount, 1);
+
+      // Simulate expired cache by setting last modified to 25 hours ago
+      final expiredTime = DateTime.now().subtract(const Duration(hours: 25));
+      cacheFile.setLastModifiedSync(expiredTime);
+
+      // Second call - should fetch again because cache expired
+      final version2 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version2, '1.2.0');
+      expect(callCount, 2);
+    });
+
+    test('valid cache (less than 24h old) does not trigger fetch', () {
+      var callCount = 0;
+      String provider() {
+        callCount++;
+        return '[{"tag_name": "1.${callCount}.0"}]';
+      }
+
+      // First call - creates cache
+      final version1 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version1, '1.1.0');
+      expect(callCount, 1);
+
+      // Simulate cache that's 23 hours old (still valid)
+      final validTime = DateTime.now().subtract(const Duration(hours: 23));
+      cacheFile.setLastModifiedSync(validTime);
+
+      // Second call - should use cache
+      final version2 = getLatestPuroVersion(
+        cacheFile: cacheFile,
+        githubReleasesProvider: provider,
+      );
+      expect(version2, '1.1.0');
+      expect(callCount, 1); // Still 1, provider wasn't called
     });
   });
 }

--- a/test/install_puro_test.dart
+++ b/test/install_puro_test.dart
@@ -1,0 +1,117 @@
+import 'package:puro_sidekick_plugin/src/install_puro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getLatestPuroVersion', () {
+    test('parses valid GitHub releases response', () {
+      const validResponse = '''
+[
+  {
+    "tag_name": "1.5.0",
+    "name": "1.5.0",
+    "draft": false,
+    "prerelease": false
+  }
+]
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => validResponse,
+      );
+      expect(version, '1.5.0');
+    });
+
+    test('parses response with multiple releases (takes first)', () {
+      const multipleReleases = '''
+[
+  {"tag_name": "2.0.0"},
+  {"tag_name": "1.5.0"},
+  {"tag_name": "1.4.0"}
+]
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => multipleReleases,
+      );
+      expect(version, '2.0.0');
+    });
+
+    test('returns fallback for rate limit error response (Map instead of List)', () {
+      const rateLimitResponse = '''
+{
+  "message": "API rate limit exceeded for 192.168.1.1.",
+  "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
+}
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => rateLimitResponse,
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('returns fallback for empty array response', () {
+      const emptyArray = '[]';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => emptyArray,
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('returns fallback for invalid JSON', () {
+      const invalidJson = 'not valid json';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => invalidJson,
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('returns fallback for missing tag_name field', () {
+      const missingTagName = '''
+[
+  {
+    "name": "1.5.0",
+    "draft": false
+  }
+]
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => missingTagName,
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('returns fallback for null tag_name', () {
+      const nullTagName = '''
+[
+  {
+    "tag_name": null,
+    "name": "1.5.0"
+  }
+]
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => nullTagName,
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('returns fallback when provider returns null', () {
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => throw Exception('Network error'),
+      );
+      expect(version, puroFallbackVersion);
+    });
+
+    test('handles HTML error page response', () {
+      const htmlResponse = '''
+<!DOCTYPE html>
+<html>
+<head><title>503 Service Unavailable</title></head>
+<body>Service Unavailable</body>
+</html>
+''';
+      final version = getLatestPuroVersion(
+        githubReleasesProvider: () => htmlResponse,
+      );
+      expect(version, puroFallbackVersion);
+    });
+  });
+}

--- a/test/version_parser_test.dart
+++ b/test/version_parser_test.dart
@@ -89,7 +89,8 @@ void main() {
     // >=3.0.0 <4.0.0 is min version 3.0.0 and max version <4 which is Flutter 3.3.10
     expect(
       await parser.testGetBestFlutterVersion(
-          flutterConstraint: '>=3.0.0 <4.0.0'),
+        flutterConstraint: '>=3.0.0 <4.0.0',
+      ),
       '3.3.10',
     );
 
@@ -140,8 +141,10 @@ void main() {
       packagePath: Directory.current,
       puroLsVersionsProvider: () => _puroLsVersions,
     );
-    expect(await parser.testGetBestFlutterVersion(dartConstraint: '>=4.0.0'),
-        null);
+    expect(
+      await parser.testGetBestFlutterVersion(dartConstraint: '>=4.0.0'),
+      null,
+    );
   });
 
   test('get min flutter version for sdk based pubspec', () async {


### PR DESCRIPTION
## Summary
- Cache puro update check for 24h
- Fix `getLatestPuroVersion()` crashing when GitHub API returns rate limit error (Map instead of List)
- Use `dcli.startFromArgs()` instead of `dcli.start()` to avoid shell interpretation of `&` in URL
- Add validation for missing/invalid `tag_name` field
- Add tests for various error scenarios

--- 

Also bump the `puroFallbackVersion` to `1.5.0`