### PR TITLE
Optimize unnecessary puro/flutter calls

### DIFF
--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -5,7 +5,6 @@ import 'package:dcli/dcli.dart' as dcli;
 import 'package:puro_sidekick_plugin/puro_sidekick_plugin.dart';
 import 'package:puro_sidekick_plugin/src/flutter_sdk.dart';
 import 'package:puro_sidekick_plugin/src/install_puro.dart';
-import 'package:puro_sidekick_plugin/src/puro.dart';
 import 'package:puro_sidekick_plugin/src/version_parser.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
@@ -177,7 +176,7 @@ Future<String?> _createPuroEnv(Version flutterSdkVersion) async {
 
     // Parse the Flutter SDK path from the output
     // Example: "Created new environment at `/Users/pascalwelsch/.puro/envs/3.38.6/flutter`"
-    final pathMatcher = RegExp(r'Created new environment at `([^`]+)`');
+    final pathMatcher = RegExp('Created new environment at `([^`]+)`');
     final output = createProgress.lines.join('\n');
     final match = pathMatcher.firstMatch(output);
     if (match != null) {

--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -5,6 +5,7 @@ import 'package:dcli/dcli.dart' as dcli;
 import 'package:puro_sidekick_plugin/puro_sidekick_plugin.dart';
 import 'package:puro_sidekick_plugin/src/flutter_sdk.dart';
 import 'package:puro_sidekick_plugin/src/install_puro.dart';
+import 'package:puro_sidekick_plugin/src/puro.dart';
 import 'package:puro_sidekick_plugin/src/version_parser.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
@@ -91,11 +92,16 @@ Future<void> initializePuro(SdkInitializerContext context) async {
   ).getMaxFlutterSdkVersionFromPubspec();
 
   // Setup puro environment
-  await _createPuroEnvironment(packageDir, versions.flutterVersion);
+  final versionString = versions.flutterVersion.toString();
+  final existingEnvs = await _getPuroEnvs();
+  String? cachedFlutterPath;
+  if (!existingEnvs.contains(versionString)) {
+    cachedFlutterPath = await _createPuroEnv(versions.flutterVersion);
+  }
   await _bindPuroToProject(packageDir, versions.flutterVersion);
 
   // Create symlink to puro flutter sdk
-  final flutterPath = await puroFlutterSdkPath(packageDir);
+  final flutterPath = cachedFlutterPath ?? await puroFlutterSdkPath(packageDir);
   final flutterBinPath = Directory(flutterPath).directory('bin');
   printVerbose('Use Puro Flutter SDK: $flutterPath');
 
@@ -114,42 +120,59 @@ Future<void> initializePuro(SdkInitializerContext context) async {
   }
 }
 
-Future<void> _createPuroEnvironment(
-  Directory packageDir,
-  Version flutterSdkVersion,
-) async {
-  final versionString = flutterSdkVersion.toString();
-  String currentEnvs = '';
-
-  // puro ls may fail if no environments exist yet
+/// Gets the list of existing Puro environments.
+/// Returns an empty set if puro ls fails.
+Future<Set<String>> _getPuroEnvs() async {
   final lsProgress = Progress.capture();
   try {
     await puro(['ls'], progress: lsProgress);
-    currentEnvs = lsProgress.lines.join('\n');
+    final output = lsProgress.lines.join('\n');
+    return parsePuroEnvironments(output);
   } catch (e, stackTrace) {
     print('puro ls failed: $e');
     print(stackTrace);
     if (lsProgress.lines.isNotEmpty) {
       print('output:\n${lsProgress.lines.join('\n')}');
     }
+    return {};
   }
+}
 
-  if (!currentEnvs.contains(versionString)) {
-    printVerbose('Create new Puro environment: $flutterSdkVersion');
-    final createProgress = Progress.capture();
-    try {
-      await puro(
-        ['create', versionString, versionString],
-        progress: createProgress,
+/// Creates a new Puro environment and returns the Flutter SDK path.
+/// Returns null if the path could not be extracted from the output.
+Future<String?> _createPuroEnv(Version flutterSdkVersion) async {
+  final versionString = flutterSdkVersion.toString();
+  printVerbose('Create new Puro environment: $flutterSdkVersion');
+
+  final createProgress = Progress.capture();
+  try {
+    await puro(
+      ['create', versionString, versionString],
+      progress: createProgress,
+    );
+
+    // Parse the Flutter SDK path from the output
+    // Example: "Created new environment at `/Users/pascalwelsch/.puro/envs/3.38.6/flutter`"
+    final pathMatcher = RegExp(r'Created new environment at `([^`]+)`');
+    final output = createProgress.lines.join('\n');
+    final match = pathMatcher.firstMatch(output);
+    if (match != null) {
+      final flutterPath = match.group(1);
+      printVerbose('Extracted Flutter SDK path from puro create: $flutterPath');
+      return flutterPath;
+    } else {
+      printVerbose(
+        'Could not extract Flutter SDK path from puro create output.\n$output',
       );
-    } catch (e, stackTrace) {
-      print('puro create failed: $e');
-      print(stackTrace);
-      if (createProgress.lines.isNotEmpty) {
-        print('output:\n${createProgress.lines.join('\n')}');
-      }
-      rethrow;
+      return null;
     }
+  } catch (e, stackTrace) {
+    print('puro create failed: $e');
+    print(stackTrace);
+    if (createProgress.lines.isNotEmpty) {
+      print('output:\n${createProgress.lines.join('\n')}');
+    }
+    rethrow;
   }
 }
 

--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -101,7 +101,23 @@ Future<void> initializePuro(SdkInitializerContext context) async {
   await _bindPuroToProject(packageDir, versions.flutterVersion);
 
   // Create symlink to puro flutter sdk
-  final flutterPath = cachedFlutterPath ?? await puroFlutterSdkPath(packageDir);
+  // Construct path directly instead of calling puro flutter --version
+  String flutterPath;
+  if (cachedFlutterPath != null) {
+    flutterPath = cachedFlutterPath;
+    printVerbose('Using cached path from puro create');
+  } else {
+    final constructedPath =
+        Directory('${puroRootDir.path}/envs/$versionString/flutter');
+    if (constructedPath.existsSync()) {
+      flutterPath = constructedPath.absolute.path;
+      printVerbose('Using constructed path: $flutterPath');
+    } else {
+      printVerbose(
+          'Constructed path not found, falling back to puro flutter --version');
+      flutterPath = await puroFlutterSdkPath(packageDir);
+    }
+  }
   final flutterBinPath = Directory(flutterPath).directory('bin');
   printVerbose('Use Puro Flutter SDK: $flutterPath');
 

--- a/lib/puro_sidekick_plugin.dart
+++ b/lib/puro_sidekick_plugin.dart
@@ -33,16 +33,14 @@ Future<void> initializePuro(SdkInitializerContext context) async {
 
   // Check if puro is already installed
   if (puroPath != null && puroPath.existsSync()) {
-    printVerbose(
-      'Puro is already installed at ${puroPath.parent.parent.absolute.path}',
-    );
     puroRootDir = puroPath.parent.parent;
+    printVerbose('Puro is already installed at ${puroRootDir.absolute.path}');
     checkForUpdates = true;
   } else {
-    // Install puro
     puroRootDir = installPuro();
   }
   dcli.env['PURO_ROOT'] = puroRootDir.absolute.path;
+  printVerbose('PURO_ROOT: ${puroRootDir.absolute.path}');
 
   // Check if puro is up to date
   if (checkForUpdates && !_alreadyCheckedForUpdate) {
@@ -93,11 +91,19 @@ Future<void> initializePuro(SdkInitializerContext context) async {
 
   // Setup puro environment
   final versionString = versions.flutterVersion.toString();
+  printVerbose('Required Flutter version: $versionString');
+
   final existingEnvs = await _getPuroEnvs();
+  printVerbose('Existing puro environments: ${existingEnvs.join(', ')}');
+
   String? cachedFlutterPath;
   if (!existingEnvs.contains(versionString)) {
+    printVerbose('Environment $versionString does not exist, creating it');
     cachedFlutterPath = await _createPuroEnv(versions.flutterVersion);
+  } else {
+    printVerbose('Environment $versionString already exists');
   }
+
   await _bindPuroToProject(packageDir, versions.flutterVersion);
 
   // Create symlink to puro flutter sdk
@@ -119,7 +125,7 @@ Future<void> initializePuro(SdkInitializerContext context) async {
     }
   }
   final flutterBinPath = Directory(flutterPath).directory('bin');
-  printVerbose('Use Puro Flutter SDK: $flutterPath');
+  printVerbose('Flutter SDK: $flutterPath');
 
   dcli.env['PURO_FLUTTER_BIN'] = flutterBinPath.absolute.path;
   createSymlink(symlinkPath, flutterPath);
@@ -143,7 +149,9 @@ Future<Set<String>> _getPuroEnvs() async {
   try {
     await puro(['ls'], progress: lsProgress);
     final output = lsProgress.lines.join('\n');
-    return parsePuroEnvironments(output);
+    final envs = parsePuroEnvironments(output);
+    printVerbose('Found ${envs.length} environment(s)');
+    return envs;
   } catch (e, stackTrace) {
     print('puro ls failed: $e');
     print(stackTrace);
@@ -158,7 +166,7 @@ Future<Set<String>> _getPuroEnvs() async {
 /// Returns null if the path could not be extracted from the output.
 Future<String?> _createPuroEnv(Version flutterSdkVersion) async {
   final versionString = flutterSdkVersion.toString();
-  printVerbose('Create new Puro environment: $flutterSdkVersion');
+  printVerbose('Creating environment: $versionString');
 
   final createProgress = Progress.capture();
   try {
@@ -174,12 +182,11 @@ Future<String?> _createPuroEnv(Version flutterSdkVersion) async {
     final match = pathMatcher.firstMatch(output);
     if (match != null) {
       final flutterPath = match.group(1);
-      printVerbose('Extracted Flutter SDK path from puro create: $flutterPath');
+      printVerbose('Extracted SDK path from output: $flutterPath');
       return flutterPath;
     } else {
-      printVerbose(
-        'Could not extract Flutter SDK path from puro create output.\n$output',
-      );
+      printVerbose('Could not extract SDK path from puro create output');
+      printVerbose('Output was:\n$output');
       return null;
     }
   } catch (e, stackTrace) {

--- a/lib/src/puro.dart
+++ b/lib/src/puro.dart
@@ -76,6 +76,31 @@ Directory getPuroStandaloneBinPath({bool createIfNotExists = false}) {
   return path;
 }
 
+/// Parses environment names from `puro ls` output.
+///
+/// The output format is:
+/// ```txt
+///     ~ stable    (stable / 3.38.5 / f6ff1529fd)
+///       beta      (beta / 3.40.0-0.2.pre / ebde138e38)
+///     * 3.27.4    (stable / 3.27.4 / d8a9f9a52e)
+/// ```
+///
+/// Returns a set of environment names like {'stable', 'beta', '3.27.4'}
+Set<String> parsePuroEnvironments(String output) {
+  final envNames = <String>{};
+  // Match lines with optional prefix (spaces, ~, *) followed by environment name and details in parentheses
+  final envPattern = RegExp(r'^\s*[~*]?\s*(\S+)\s+\(', multiLine: true);
+
+  for (final match in envPattern.allMatches(output)) {
+    final envName = match.group(1);
+    if (envName != null) {
+      envNames.add(envName);
+    }
+  }
+
+  return envNames;
+}
+
 /// Thrown when puro is not found
 class PuroNotFoundException implements Exception {
   @override

--- a/test/puro_environments_parser_test.dart
+++ b/test/puro_environments_parser_test.dart
@@ -1,0 +1,138 @@
+import 'package:puro_sidekick_plugin/src/puro.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parsePuroEnvironments', () {
+    test('parses environment names from puro ls output', () {
+      const output = '''
+[i] Environments:
+    ~ stable    (stable / 3.38.5 / f6ff1529fd)
+      beta      (beta / 3.40.0-0.2.pre / ebde138e38)
+      master    (3.33.0-1.0.pre-1465 / 1e1908dc28)
+      3.10.6    (stable / 3.10.6 / f468f3366c)
+      3.35.7    (stable / 3.35.7 / adc9010625)
+      3.10.0    (stable / 3.10.0 / 84a1e904f4)
+    * 3.27.4    (stable / 3.27.4 / d8a9f9a52e)
+      noa       (stable / 3.10.2 / 9cd3d0d9ff)
+      dart_3-5  (stable / 3.24.5 / dec2ee5c1f)
+      eurowings (stable / 3.7.12 / 4d9e56e694)
+      3.32.8    (stable / 3.32.8 / edada7c56e)
+      3.38.6    (stable / 3.38.6 / 8b87286849)
+      3.24.5    (stable / 3.24.5 / dec2ee5c1f)
+      3.35.2    (stable / 3.35.2 / 05db968908)
+      3.38.4    (stable / 3.38.4 / 66dd93f9a2)
+      dart_3-6  (stable / 3.27.4 / d8a9f9a52e)
+      3.38.3    (stable / 3.38.3 / 19074d12f7)
+      dart_3-8  (stable / 3.32.5 / fcf2c11572)
+      3.38.2    (stable / 3.38.2 / f5a8537f90)
+      dart_3-7  (stable / 3.29.3 / ea121f8859)
+      3.0.5     (stable / 3.0.5 / f1875d570e)
+      3.24.0    (stable / 3.24.0 / 80c2e84975)
+      3.24.1    (stable / 3.24.1 / 5874a72aa4)
+
+    Use `puro create <name>` to create an environment, or `puro use <name>` to switch
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, contains('stable'));
+      expect(envs, contains('beta'));
+      expect(envs, contains('master'));
+      expect(envs, contains('3.10.6'));
+      expect(envs, contains('3.27.4'));
+      expect(envs, contains('3.38.6'));
+      expect(envs, contains('noa'));
+      expect(envs, contains('dart_3-5'));
+      expect(envs, contains('eurowings'));
+
+      // Total environments
+      expect(envs.length, 23);
+    });
+
+    test('handles environment with ~ prefix', () {
+      const output = '''
+[i] Environments:
+    ~ stable    (stable / 3.38.5 / f6ff1529fd)
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, contains('stable'));
+      expect(envs.length, 1);
+    });
+
+    test('handles environment with * prefix', () {
+      const output = '''
+[i] Environments:
+    * 3.27.4    (stable / 3.27.4 / d8a9f9a52e)
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, contains('3.27.4'));
+      expect(envs.length, 1);
+    });
+
+    test('handles environment without prefix', () {
+      const output = '''
+[i] Environments:
+      beta      (beta / 3.40.0-0.2.pre / ebde138e38)
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, contains('beta'));
+      expect(envs.length, 1);
+    });
+
+    test('does not match version numbers inside parentheses', () {
+      const output = '''
+[i] Environments:
+    ~ stable    (stable / 3.38.5 / f6ff1529fd)
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      // Should only match 'stable', not '3.38.5'
+      expect(envs, contains('stable'));
+      expect(envs, isNot(contains('3.38.5')));
+      expect(envs.length, 1);
+    });
+
+    test('returns empty set for empty output', () {
+      const output = '';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, isEmpty);
+    });
+
+    test('returns empty set when no environments exist', () {
+      const output = '''
+[i] Environments:
+
+    Use `puro create <name>` to create an environment, or `puro use <name>` to switch
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, isEmpty);
+    });
+
+    test('handles environments with varying spacing', () {
+      const output = '''
+[i] Environments:
+  ~ stable    (stable / 3.38.5 / f6ff1529fd)
+    beta      (beta / 3.40.0-0.2.pre / ebde138e38)
+      * master    (3.33.0-1.0.pre-1465 / 1e1908dc28)
+''';
+
+      final envs = parsePuroEnvironments(output);
+
+      expect(envs, contains('stable'));
+      expect(envs, contains('beta'));
+      expect(envs, contains('master'));
+      expect(envs.length, 3);
+    });
+  });
+}


### PR DESCRIPTION
This PR contains multiple otimizations:
- Extract Flutter SDK path from `puro create` output - Eliminates `puro flutter --version` call when creating new environments (~1-2 sec)
- Construct Flutter SDK path directly from `$PURO_ROOT/envs/$version/flutter` - Eliminates `puro flutter --version` call for existing environments (~2-3 sec, runs on every initialization)