### PR TITLE
Add SIDEKICK_PURO_INSTALL_GLOBAL env var to skip interactive prompt

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -53,3 +53,14 @@ jobs:
 
       - name: Install dependencies using the Puro Sidekick Plugin
         run: cd ci_test && ./skt flutter pub get
+
+  build-global:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies using the Puro Sidekick Plugin (global)
+        run: cd ci_test && ./skt flutter pub get
+        env:
+          SIDEKICK_PURO_INSTALL_GLOBAL: 'y'

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -14,10 +14,11 @@ Directory installPuro({
 }) {
   // Allow forcing global install via env var, useful in CI
   final envValue = Platform.environment['SIDEKICK_PURO_INSTALL_GLOBAL'];
-  final installGlobal = envValue ?? dcli.ask(
-    "Puro is not installed.\nDo you want to install Puro global? (y/N)",
-    defaultValue: 'n',
-  );
+  final installGlobal = envValue ??
+      dcli.ask(
+        "Puro is not installed.\nDo you want to install Puro global? (y/N)",
+        defaultValue: 'n',
+      );
 
   final latestVersion = getLatestPuroVersion();
   print('Download Puro $latestVersion');

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -50,6 +50,15 @@ Directory installPuroGlobal(String version, dcli.Progress? progress) {
     throw PuroInstallationFailedException();
   }
 
+  // The install script updates ~/.profile but the current process still has
+  // the old PATH. Add the default puro bin directory so getPuroPath() works.
+  final puroBin = Directory(
+    '${Platform.environment['HOME']}/.puro/bin',
+  );
+  if (puroBin.existsSync()) {
+    dcli.env['PATH'] = '${puroBin.path}:${dcli.env['PATH'] ?? ''}';
+  }
+
   final puroPath = getPuroPath();
   if (puroPath == null) {
     throw PuroInstallationFailedException();

--- a/lib/src/install_puro.dart
+++ b/lib/src/install_puro.dart
@@ -12,7 +12,9 @@ const puroFallbackVersion = '1.5.0';
 Directory installPuro({
   dcli.Progress? progress,
 }) {
-  final installGlobal = dcli.ask(
+  // Allow forcing global install via env var, useful in CI
+  final envValue = Platform.environment['SIDEKICK_PURO_INSTALL_GLOBAL'];
+  final installGlobal = envValue ?? dcli.ask(
     "Puro is not installed.\nDo you want to install Puro global? (y/N)",
     defaultValue: 'n',
   );


### PR DESCRIPTION
## Summary

- Add `SIDEKICK_PURO_INSTALL_GLOBAL` env var to `installPuro()` — when set, skips the interactive `dcli.ask()` prompt and uses the env value directly
- Add `build-global` CI job that uses this env var to test the global puro install path

🤖 Generated with [Claude Code](https://claude.com/claude-code)